### PR TITLE
Drop support for Laravel 9 and 10

### DIFF
--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Setup PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
           tools: "composer:v2"
           coverage: "none"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2]
         dependency-version: ["prefer-stable"]
         os: ["ubuntu-latest"]
 

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "ext-dom": "*",
     "ext-simplexml": "*",
     "ext-libxml": "*",
-    "symfony/dom-crawler": "^5.4.21|^6.2.7|^v7.2.0",
-    "symfony/css-selector": "^5.4.21|^6.2.7|^v7.2.0",
+    "symfony/dom-crawler": "^v7.2.0",
+    "symfony/css-selector": "^v7.2.0",
     "guzzlehttp/guzzle": "^7.5.0",
     "illuminate/support": "^11.0|^12.0",
     "nesbot/carbon": "^2.66.0|^3.0",
@@ -36,10 +36,10 @@
   },
   "require-dev": {
     "phpdocumentor/reflection-docblock": "^5.3.0",
-    "symfony/yaml": "^5.4.21|^6.2.7|^7.2",
+    "symfony/yaml": "^7.2.0",
     "phpunit/phpunit": "^9.6.4|^10.0.15|^11.1",
     "spatie/phpunit-snapshot-assertions": "^4.2.16",
-    "symfony/var-dumper": "^5.4.21|^6.2.7|^7.2",
+    "symfony/var-dumper": "^7.2.0",
     "mockery/mockery": "^1.5.1",
     "phpstan/phpstan": "^2.1.6",
     "laravel/pint": "^1.13"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "symfony/dom-crawler": "^5.4.21|^6.2.7|^v7.2.0",
     "symfony/css-selector": "^5.4.21|^6.2.7|^v7.2.0",
     "guzzlehttp/guzzle": "^7.5.0",
-    "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/support": "^11.0|^12.0",
     "nesbot/carbon": "^2.66.0|^3.0",
     "laminas/laminas-xml": "^1.5.0",
     "laminas/laminas-feed": "^2.20.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "reader"
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-json": "*",
     "ext-dom": "*",
     "ext-simplexml": "*",

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
   "require-dev": {
     "phpdocumentor/reflection-docblock": "^5.3.0",
     "symfony/yaml": "^7.2.0",
-    "phpunit/phpunit": "^9.6.4|^10.0.15|^11.1",
-    "spatie/phpunit-snapshot-assertions": "^4.2.16",
+    "phpunit/phpunit": "^10.0.15|^11.1",
+    "spatie/phpunit-snapshot-assertions": "^5.2.2",
     "symfony/var-dumper": "^7.2.0",
     "mockery/mockery": "^1.5.1",
     "phpstan/phpstan": "^2.1.6",

--- a/tests/__snapshots__/HeraRssCrawlerTest__test_parse_feed with data set Zeit__1.yml
+++ b/tests/__snapshots__/HeraRssCrawlerTest__test_parse_feed with data set Zeit__1.yml
@@ -1,5 +1,5 @@
-title: 'ZEIT ONLINE | Nachrichten, News, Hintergründe und Debatten'
-description: 'Aktuelle Nachrichten, Kommentare, Analysen und Hintergrundberichte aus Politik, Wirtschaft, Gesellschaft, Wissen, Kultur und Sport lesen Sie auf ZEIT ONLINE.'
+title: 'DIE ZEIT | Nachrichten, News, Hintergründe und Debatten'
+description: 'Aktuelle Nachrichten, Kommentare, Analysen und Hintergrundberichte aus Politik, Wirtschaft, Gesellschaft, Wissen, Kultur und Sport lesen Sie bei der ZEIT.'
 feedUrl: 'https://newsfeed.zeit.de/index'
 id: 'https://www.zeit.de/index'
 language: de-de


### PR DESCRIPTION
This PR removes support for Laravel 9 and 10 and raises the minimum required PHP version to 8.2

closes #9